### PR TITLE
添加流体包裹兼容

### DIFF
--- a/src/main/java/io/github/forgestove/create_cyber_goggles/core/factory/ClientItemListTooltipComponent.java
+++ b/src/main/java/io/github/forgestove/create_cyber_goggles/core/factory/ClientItemListTooltipComponent.java
@@ -1,4 +1,5 @@
 package io.github.forgestove.create_cyber_goggles.core.factory;
+import io.github.forgestove.create_cyber_goggles.core.gui.AbstractItemGridRenderer;
 import io.github.forgestove.create_cyber_goggles.core.util.SlotUtil;
 import net.minecraft.client.gui.*;
 import net.minecraft.client.gui.screens.inventory.tooltip.ClientTooltipComponent;
@@ -48,7 +49,9 @@ public final class ClientItemListTooltipComponent implements ClientTooltipCompon
 	private void renderSlot(GuiGraphics gui, Font font, ItemStack stack, int x, int y) {
 		gui.blitSprite(SlotUtil.SLOT, x, y, 0, SlotUtil.SIZE, SlotUtil.SIZE);
 		gui.renderItem(stack, x + 1, y + 1);
-		gui.renderItemDecorations(font, stack, x + 1, y + 1);
+		if (AbstractItemGridRenderer.isCFLCompressedTank(stack) && stack.getCount() > 1)
+			gui.renderItemDecorations(font, stack, x + 1, y + 1, AbstractItemGridRenderer.formatFluidAmount(stack.getCount()));
+		else gui.renderItemDecorations(font, stack, x + 1, y + 1);
 	}
 	private int indentPixels(@NotNull Font font) {
 		return indent * font.width(" ");

--- a/src/main/java/io/github/forgestove/create_cyber_goggles/core/gui/AbstractItemGridRenderer.java
+++ b/src/main/java/io/github/forgestove/create_cyber_goggles/core/gui/AbstractItemGridRenderer.java
@@ -2,11 +2,17 @@ package io.github.forgestove.create_cyber_goggles.core.gui;
 import com.mojang.blaze3d.systems.RenderSystem;
 import io.github.forgestove.create_cyber_goggles.core.api.TooltipOverlayRenderer;
 import io.github.forgestove.create_cyber_goggles.core.util.*;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.Mth;
 import net.minecraft.world.item.ItemStack;
+import net.neoforged.neoforge.capabilities.Capabilities;
+import net.neoforged.neoforge.fluids.FluidStack;
 import org.jetbrains.annotations.*;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.*;
 
 import static io.github.forgestove.create_cyber_goggles.core.util.CCGUtil.mc;
@@ -16,6 +22,8 @@ public abstract class AbstractItemGridRenderer implements TooltipOverlayRenderer
 	private static final int LIGHT = 0xFFFFFFFF;
 	private static final int DARK = 0xFF555555;
 	private static final int DARKER = 0xFF373737;
+	private static final ResourceLocation CFL_COMPRESSED_TANK_ID =
+		ResourceLocation.fromNamespaceAndPath("fluidlogistics", "compressed_storage_tank");
 	public static int resolveColumns(OverlayData data) {
 		return Mth.clamp(data.columns(), 1, Math.max(1, data.items().size()));
 	}
@@ -46,9 +54,29 @@ public abstract class AbstractItemGridRenderer implements TooltipOverlayRenderer
 			var item = items.get(i);
 			gui.renderItem(item, slotX + 1, slotY + 1);
 			if (zeroCountSlots.contains(i)) gui.renderItemDecorations(mc.font, item, slotX + 1, slotY + 1, "0");
+			else if (isCFLCompressedTank(item) && item.getCount() > 1)
+				gui.renderItemDecorations(mc.font, item, slotX + 1, slotY + 1, formatFluidAmount(item.getCount()));
 			else gui.renderItemDecorations(mc.font, item, slotX + 1, slotY + 1);
 		}
 		pose.popPose();
+	}
+	public static boolean isCFLCompressedTank(ItemStack stack) {
+		if (stack.isEmpty()) return false;
+		return BuiltInRegistries.ITEM.getKey(stack.getItem()).equals(CFL_COMPRESSED_TANK_ID);
+	}
+	public static int getCFLTankAmount(ItemStack stack) {
+		if (!isCFLCompressedTank(stack)) return 0;
+		var handler = stack.getCapability(Capabilities.FluidHandler.ITEM);
+		if (handler == null) return 0;
+		FluidStack fluid = handler.getFluidInTank(0);
+		return fluid.isEmpty() ? 0 : fluid.getAmount();
+	}
+	public static @NotNull String formatFluidAmount(int amountMb) {
+		if (amountMb % 1000 == 0) return amountMb / 1000 + "B";
+		return BigDecimal.valueOf(amountMb)
+			.divide(BigDecimal.valueOf(1000), 1, RoundingMode.DOWN)
+			.stripTrailingZeros()
+			.toPlainString() + "B";
 	}
 	public static void renderPanel(GuiGraphics gui, int width, int height, float r, float g, float b) {
 		RenderSystem.setShaderColor(r, g, b, 1F);

--- a/src/main/java/io/github/forgestove/create_cyber_goggles/core/gui/PackageItemRenderer.java
+++ b/src/main/java/io/github/forgestove/create_cyber_goggles/core/gui/PackageItemRenderer.java
@@ -17,7 +17,8 @@ public final class PackageItemRenderer extends AbstractItemGridRenderer {
         for (var i = 0; i < contents.getSlots(); i++) {
             var itemstack = contents.getStackInSlot(i);
             if (itemstack.isEmpty()) continue;
-            items.add(itemstack);
+            int amount = getCFLTankAmount(itemstack);
+            items.add(amount > 0 ? itemstack.copyWithCount(amount) : itemstack);
         }
         return items.isEmpty() ? null : new OverlayData(items, 3);
     }


### PR DESCRIPTION
让CCG在显示包裹与红石请求器信息时可以准确显示出CFL的流体数量