### PR TITLE
修复准星指向实体时tooltip 完全不上移

### DIFF
--- a/src/main/java/io/github/forgestove/create_cyber_goggles/core/event/TooltipOverlay.java
+++ b/src/main/java/io/github/forgestove/create_cyber_goggles/core/event/TooltipOverlay.java
@@ -28,6 +28,7 @@ import static io.github.forgestove.create_cyber_goggles.core.util.CCGUtil.*;
 public final class TooltipOverlay {
 	public static float hoverTicks;
 	private static ItemStack lastItemStack = ItemStack.EMPTY;
+	private static boolean liftAboveGoggle;
 	public static void register(@NotNull RegisterGuiLayersEvent event) {
 		event.registerAbove(VanillaGuiLayers.HOTBAR, getCCGRes("tooltip_overlay"), TooltipOverlay::renderOverlay);
 	}
@@ -49,6 +50,8 @@ public final class TooltipOverlay {
 		}
 		hoverTicks = Math.min(8, hoverTicks + getRealtimeDeltaTicks());
 		lastItemStack = itemStack;
+		// 锁存"是否抬到目镜信息上方"，使淡出期间保持在偏移后的位置，而非随护目镜层的 hoverTicks 提前落回原位
+		liftAboveGoggle = GoggleOverlayRenderer.hoverTicks > 0;
 		renderItemStack(gui, itemStack);
 	}
 	public static @NotNull ItemStack toRenderItemStack() {
@@ -91,8 +94,8 @@ public final class TooltipOverlay {
 			tooltipWidth = Math.max(tooltipWidth, component.getWidth(mc.font));
 			tooltipHeight += component.getHeight();
 		}
-		var goggleFade = Mth.clamp(GoggleOverlayRenderer.hoverTicks / 24F, 0, 1);
-		if (goggleFade > 0) y -= (int) ((tooltipHeight + 10) * goggleFade);
+		// 物品悬浮框淡入淡出全程停留在该偏移位置
+		if (liftAboveGoggle) y -= tooltipHeight + 10;
 		x = Mth.clamp(x, 0, width - tooltipWidth);
 		y = Mth.clamp(y, 16, height - tooltipHeight - 100);
 		renderTooltip(gui, itemStack, components, x, y, tooltipWidth, tooltipHeight, back.getRGB(), top.getRGB(), bot.getRGB());

--- a/src/main/java/io/github/forgestove/create_cyber_goggles/mixin/goggles/GoggleOverlayRendererMixin.java
+++ b/src/main/java/io/github/forgestove/create_cyber_goggles/mixin/goggles/GoggleOverlayRendererMixin.java
@@ -25,7 +25,7 @@ import java.util.*;
 import static io.github.forgestove.create_cyber_goggles.core.util.CCGUtil.*;
 @Mixin(GoggleOverlayRenderer.class)
 public abstract class GoggleOverlayRendererMixin {
-	@Unique private static BlockHitResult ccg$lastBlockHitResult;
+	@Unique private static HitResult ccg$lastHitResult;
 	@Inject(method = "renderOverlay", at = @At("HEAD"), cancellable = true)
 	private static void renderOverlay(CallbackInfo ci) {
 		if (!CCG.config.goggles.disableInScreenGoggles || isInGame()) return;
@@ -106,13 +106,16 @@ public abstract class GoggleOverlayRendererMixin {
 		if (original instanceof BlockHitResult bhr && bhr.getType() == Type.BLOCK && mc.level != null) {
 			var be = mc.level.getBlockEntity(bhr.getBlockPos());
 			if (be instanceof IHaveGoggleInformation || be instanceof IHaveHoveringInformation) {
-				ccg$lastBlockHitResult = bhr;
+				ccg$lastHitResult = bhr;
 				return original;
 			}
-			// 非渲染方块：淡出时返回缓存的上一个渲染方块
-			return ccg$isFadingOut() && ccg$lastBlockHitResult != null ? ccg$lastBlockHitResult : original;
+		} else if (original instanceof EntityHitResult ehr && ehr.getEntity() instanceof IHaveGoggleInformation) {
+			//放置在地面的实现目镜信息接口的实体
+			ccg$lastHitResult = ehr;
+			return original;
 		}
-		return ccg$isFadingOut() && ccg$lastBlockHitResult != null ? ccg$lastBlockHitResult : original;
+		// 非渲染目标：淡出时返回缓存的上一个渲染目标
+		return ccg$isFadingOut() && ccg$lastHitResult != null ? ccg$lastHitResult : original;
 	}
 	@Unique
 	private static boolean ccg$isFadingOut() {
@@ -120,8 +123,8 @@ public abstract class GoggleOverlayRendererMixin {
 		var hit = mc.hitResult;
 		if (hit instanceof BlockHitResult bhr && bhr.getType() == Type.BLOCK && mc.level != null) {
 			var be = mc.level.getBlockEntity(bhr.getBlockPos());
-			if (be instanceof IHaveGoggleInformation || be instanceof IHaveHoveringInformation) return false; // 当前方块会渲染 tooltip
-		}
+			if (be instanceof IHaveGoggleInformation || be instanceof IHaveHoveringInformation) return false;
+		} else if (hit instanceof EntityHitResult ehr && ehr.getEntity() instanceof IHaveGoggleInformation) return false;
 		return GoggleOverlayRenderer.hoverTicks > 0; // 无有效 tooltip 且之前有渲染 → 淡出
 	}
 	@ModifyExpressionValue(method = "renderOverlay", at = @At(value = "INVOKE", target = "Ljava/util/List;isEmpty()Z", ordinal = 1))


### PR DESCRIPTION
<img width="2560" height="1387" alt="image" src="https://github.com/user-attachments/assets/fba05a47-5356-4002-9dbf-592c45cf8a12" />
当准星指向实体时（EntityHitResult），CCG 误判为"正在淡出"，于是 wrapFadeClamp 每帧把 hoverTicks 减 3，hoverTicks 被永久压在 0~1。结果 goggleFade 约等于 0 ，导致CCG 的物品 tooltip 完全不上移与Create 的流体信息框重叠 。此外还更新了淡入/淡出逻辑，始终在偏移后的位置进行左右淡入/淡出。
